### PR TITLE
ghostscript 9.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
 FROM node:carbon-stretch
 
-#Install libvips because of sharp https://github.com/TailorBrands/docker-libvips/blob/c4b0f8e559abd858123654470af5bc70f48c0822/8.6.1/Dockerfile
-RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  automake build-essential curl \
-  cdbs debhelper dh-autoreconf flex bison \
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  automake build-essential curl nano \
+  cdbs debhelper dh-autoreconf flex bison
+
+RUN \
+  # Build ghostscript
+  cd /tmp && \
+  curl -L -O https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs925/ghostscript-9.25.tar.gz && \
+  tar zxvf ghostscript-9.25.tar.gz && \
+  cd /tmp/ghostscript-9.25 && \
+  ./configure && \
+  make so && \
+  cp sobin/* /usr/lib/x86_64-linux-gnu
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
   libjpeg-dev libtiff-dev libpng-dev libgif-dev librsvg2-dev libpoppler-glib-dev zlib1g-dev fftw3-dev liblcms2-dev \
   liblcms2-dev libmagickwand-dev libfreetype6-dev libpango1.0-dev libfontconfig1-dev libglib2.0-dev libice-dev \
   gettext pkg-config libxml-parser-perl libexif-gtk-dev liborc-0.4-dev libopenexr-dev libmatio-dev libxml2-dev \
-  libcfitsio-dev libopenslide-dev libwebp-dev libgsf-1-dev libgirepository1.0-dev gtk-doc-tools \
-  ghostscript libgs-dev nano
+  libcfitsio-dev libopenslide-dev libwebp-dev libgsf-1-dev libgirepository1.0-dev gtk-doc-tools
 
+#Install libvips because of sharp https://github.com/TailorBrands/docker-libvips/blob/c4b0f8e559abd858123654470af5bc70f48c0822/8.6.1/Dockerfile
 ENV LIBVIPS_VERSION_MAJOR 8
 ENV LIBVIPS_VERSION_MINOR 6
 ENV LIBVIPS_VERSION_PATCH 1
@@ -19,7 +30,7 @@ ENV LIBVIPS_VERSION $LIBVIPS_VERSION_MAJOR.$LIBVIPS_VERSION_MINOR.$LIBVIPS_VERSI
 RUN \
   # Build libvips
   cd /tmp && \
-  curl -L -O https://github.com/jcupitt/libvips/releases/download/v$LIBVIPS_VERSION/vips-$LIBVIPS_VERSION.tar.gz && \
+  curl -L -O https://github.com/libvips/libvips/releases/download/v$LIBVIPS_VERSION/vips-$LIBVIPS_VERSION.tar.gz && \
   tar zxvf vips-$LIBVIPS_VERSION.tar.gz && \
   cd /tmp/vips-$LIBVIPS_VERSION && \
   ./configure --enable-debug=no --without-python $1 && \
@@ -38,7 +49,11 @@ RUN \
 RUN adduser node root
 RUN mkdir /home/node/client
 RUN mkdir /home/node/server
-WORKDIR /home/node/server
+RUN chown -R node:root /home/node
+RUN chmod -R 775 /home/node
+
+# Openshift does not run containers as root, use our new user.
+USER node
 
 # install node modules for root, server and client
 WORKDIR /home/node/
@@ -56,11 +71,4 @@ COPY --chown=node:root client-package.json ./package.json
 COPY --chown=node:root client-package-lock.json ./package-lock.json
 RUN npm install
 
-RUN chown -R node:root /home/node
-RUN chmod -R 775 /home/node
 WORKDIR /home/node
-
-
-# Openshift does not run containers as root, use our new user.
-USER node
-


### PR DESCRIPTION
Hab nicht alle Versionen durchprobiert, ab 9.23 ging es. In den Paketquellen ist nur 9.20 drin und damit erhält man ein etwa 8000x10000 Pixel großes JPEG aus den Test PDFs. Mit 9.25 sind sie sinnvoll groß, so 3000x4000 (er nehme an, dass das die grundsätzliche Ursache ist). Außerdem diverse Bugfixes und Security patches seit 9.20.

Jetzt gibt es nur noch ein Problem: das Dockerfile hier kompiliert nicht. `make so` zum Erstellen der ghostscript shared library schlägt fehl. In einem sauberen Dockerfile funktioniert es und ghostscript4js nutzt dann auch 9.25. Bevor ich jetzt noch länger daran sitze wollte ich es mal pushen und vielleicht findet einer von euch das Problem.